### PR TITLE
Fixed data length check and add padding

### DIFF
--- a/machine_report.sh
+++ b/machine_report.sh
@@ -143,8 +143,10 @@ PRINT_DATA() {
 
     # Truncate or pad data
     local data_len=${#data}
-    if (( data_len >= MAX_DATA_LEN || data_len == MAX_DATA_LEN-1 )); then
-        data=$(echo "$data" | cut -c 1-$((MAX_DATA_LEN-3-2)))...
+#    if (( data_len >= MAX_DATA_LEN || data_len == MAX_DATA_LEN-1 )); then    # the original line
+    if (( data_len > MAX_DATA_LEN || data_len == MAX_DATA_LEN-1 )); then      # changed '>=' to '>'
+        data=$(echo "$data" | cut -c 1-$((MAX_DATA_LEN-3-2)))...                # the original line
+        data=$(printf "%-${max_data_len}s" "$data")                             # added a line to pad after truncation
     else
         data=$(printf "%-${max_data_len}s" "$data")
     fi


### PR DESCRIPTION
Fixes a data padding issue in the `PRINT_DATA()` function that appears on Ubuntu 25.10 and possibly other systems. 

Changed the if condition regarding data_len in PRINT_DATA() from `data_len >= MAX_DATA_LEN` to `data_len > MAX_DATA_LEN` to correct bar graph padding. Also added a line to pad the data after it is truncated in the same if block.

See Issue https://github.com/usgraphics/usgc-machine-report/issues/23 for more information about the error. (I can't seem to link the two either due to permissions or my own level of knowledge)